### PR TITLE
Improve Timestamp String on Ready Phase

### DIFF
--- a/Assets/Scripts/UI/TImeDisplayer.cs
+++ b/Assets/Scripts/UI/TImeDisplayer.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
@@ -18,10 +19,21 @@ public class TImeDisplayer : MonoBehaviour
 
     void Update()
     {
-        int timenowInt = (int)timeProvider.AudioTime;
+        // Lock AudioTime variable for real
+        float ctime = timeProvider.AudioTime;
+        int timenowInt = (int)ctime;
         int minute = timenowInt / 60;
         int second = timenowInt - (60 * minute);
-        double mili = (timeProvider.AudioTime - timenowInt) * 10000;
-        text.text = string.Format("{0}:{1:00}.{2:0000}", minute, second, mili);
+        double mili = (ctime - timenowInt) * 10000;
+
+        // Make timing display "cleaner" on negative timing.
+        if (ctime < 0) {
+            minute = Math.Abs(minute);
+            second = Math.Abs(second);
+            mili   = Math.Abs(mili);
+            text.text = string.Format("-{0}:{1:00}.{2:000}", minute, second, mili / 10);
+        } else {
+            text.text = string.Format("{0}:{1:00}.{2:0000}", minute, second, mili);
+        }
     }
 }


### PR DESCRIPTION
Changes potential of `-M:-S:-MS` format into `-0M:0S:0MS` (`millis` side only retains 3 decimal instead 4 due to minus sign).

![image](https://user-images.githubusercontent.com/9847780/216684378-2e8d9bc4-faf3-4a53-85c4-036718522706.png)
~~do not mind with some resource memes there, I shouldn't symlinked it.~~
