### PR TITLE
Fix known Star on Slide Angles

### DIFF
--- a/Assets/Scripts/AudioTimeProvider.cs
+++ b/Assets/Scripts/AudioTimeProvider.cs
@@ -41,6 +41,13 @@ public class AudioTimeProvider : MonoBehaviour
         isStart = false;
     }
 
+    public float CurrentSpeed
+    {
+        get {
+            return isRecord ? Time.timeScale : speed;
+        }
+    }
+
     // Update is called once per frame
     void Update()
     {
@@ -52,7 +59,7 @@ public class AudioTimeProvider : MonoBehaviour
             }
             else
             {
-                AudioTime = (Time.realtimeSinceStartup - startTime) *speed + offset;
+                AudioTime = (Time.realtimeSinceStartup - startTime) * speed + offset;
             }
         }
     }

--- a/Assets/Scripts/JsonDataLoader.cs
+++ b/Assets/Scripts/JsonDataLoader.cs
@@ -642,6 +642,17 @@ public class JsonDataLoader : MonoBehaviour
 
         SliCompo.isMirror = isMirror;
         SliCompo.isJustR = detectJustType(note.noteContent);
+        if ((slideIndex - 26) > 0 && (slideIndex - 26) <= 8)
+        {
+            // known slide sprite issue
+            //    1 2 3 4 5 6 7 8
+            // p  X X X X X X O O
+            // q  X O O X X X X X
+            int pqEndPos = slideIndex - 26;
+            SliCompo.isSpecialFlip = isMirror == (pqEndPos == 7 || pqEndPos == 8);
+        } else {
+            SliCompo.isSpecialFlip = isMirror;
+        }
         SliCompo.speed = noteSpeed * timing.HSpeed;
         SliCompo.timeStar = (float)timing.time;
         SliCompo.startPosition = note.startPosition;

--- a/Assets/Scripts/Notes/SlideDrop.cs
+++ b/Assets/Scripts/Notes/SlideDrop.cs
@@ -16,6 +16,7 @@ public class SlideDrop : MonoBehaviour
 
     public bool isMirror;
     public bool isJustR;
+    public bool isSpecialFlip; // fixes known star problem
     public bool isEach;
     public bool isBreak;
     public bool isGroupPart;
@@ -152,9 +153,9 @@ public class SlideDrop : MonoBehaviour
                 alpha = alpha < 0.5f ? 0.5f : alpha;
             }
             spriteRenderer_star.color = new Color(1, 1, 1, alpha);
-            star_slide.transform.localScale = new Vector3(alpha+0.5f, alpha + 0.5f, alpha + 0.5f);
+            star_slide.transform.localScale = new Vector3(alpha + 0.5f, alpha + 0.5f, alpha + 0.5f);
             star_slide.transform.position = slidePositions[0];
-            star_slide.transform.rotation = slideRotations[0];
+            applyStarRotation(slideRotations[0]);
         }
         if (timing > 0f)
         {
@@ -194,8 +195,10 @@ public class SlideDrop : MonoBehaviour
                 //star_slide.transform.rotation = slideRotations[index];
                 var delta = Mathf.DeltaAngle(slideRotations[index + 1].eulerAngles.z , slideRotations[index].eulerAngles.z) * (pos - index);
                 delta = Mathf.Abs(delta);
-                star_slide.transform.rotation = Quaternion.Euler(0f, 0f,
-                     Mathf.MoveTowardsAngle(slideRotations[index].eulerAngles.z, slideRotations[index + 1].eulerAngles.z, delta)
+                applyStarRotation(
+                     Quaternion.Euler(0f, 0f,
+                         Mathf.MoveTowardsAngle(slideRotations[index].eulerAngles.z, slideRotations[index + 1].eulerAngles.z, delta)
+                     )
                 );
                 for (int i = 0; i < pos; i++)
                 {
@@ -218,5 +221,14 @@ public class SlideDrop : MonoBehaviour
         return new Vector3(
             distance * Mathf.Cos((startPosition * -2f + 5f) * 0.125f * Mathf.PI),
             distance * Mathf.Sin((startPosition * -2f + 5f) * 0.125f * Mathf.PI));
+    }
+    void applyStarRotation(Quaternion newRotation)
+    {
+        var halfFlip = newRotation.eulerAngles;
+        halfFlip.z += 180f;
+        if (isSpecialFlip)
+            star_slide.transform.rotation = Quaternion.Euler(halfFlip);
+        else
+            star_slide.transform.rotation = newRotation;
     }
 }

--- a/Assets/Scripts/Notes/SlideDrop.cs
+++ b/Assets/Scripts/Notes/SlideDrop.cs
@@ -88,7 +88,7 @@ public class SlideDrop : MonoBehaviour
         foreach (var bars in slideBars)
         {
             slidePositions.Add(bars.transform.position);
-            slideRotations.Add( Quaternion.Euler(bars.transform.rotation.eulerAngles+new Vector3(0f,0f,15f)));
+            slideRotations.Add(Quaternion.Euler(bars.transform.rotation.eulerAngles + new Vector3(0f, 0f, 18f)));
         }
         foreach (var gm in slideBars)
         {

--- a/Assets/Scripts/Notes/StarDrop.cs
+++ b/Assets/Scripts/Notes/StarDrop.cs
@@ -136,6 +136,7 @@ public class StarDrop : MonoBehaviour
         var timing = timeProvider.AudioTime - time;
         var distance = timing * speed + 4.8f;
         var destScale = distance * 0.4f + 0.51f;
+        var songSpeed = timeProvider.CurrentSpeed;
         if (destScale < 0f) { 
             destScale = 0f;
             return;
@@ -162,14 +163,13 @@ public class StarDrop : MonoBehaviour
             Destroy(gameObject); 
         }
 
-        transform.Rotate(0f, 0f, -180f*Time.deltaTime/rotateSpeed);
+        if (timeProvider.isStart)
+            transform.Rotate(0f, 0f, -180f * Time.deltaTime * songSpeed / rotateSpeed);
 
         tapLine.transform.rotation = Quaternion.Euler(0, 0, -22.5f + (-45f * (startPosition - 1)));
 
         if (distance < 1.225f)
         {
-
-
             transform.localScale = new Vector3(destScale, destScale);
 
             distance = 1.225f;

--- a/Assets/Scripts/Notes/WifiDrop.cs
+++ b/Assets/Scripts/Notes/WifiDrop.cs
@@ -56,7 +56,7 @@ public class WifiDrop : MonoBehaviour
             if (isEach) spriteRenderer_star[i].sprite = eachStar;
             else if (isBreak) spriteRenderer_star[i].sprite = breakStar;
             else spriteRenderer_star[i].sprite = normalStar;
-            star_slide[i].transform.rotation = Quaternion.Euler(0, 0, -22.5f + (-45f * (i + 3 + startPosition)));
+            star_slide[i].transform.rotation = Quaternion.Euler(0, 0, -22.5f * (8 + i + 2 * (startPosition - 1)));
             SlidePositionEnd[i] = getPositionFromDistance(4.8f, i + 3 + startPosition);
             star_slide[i].SetActive(false);
         }

--- a/Assets/Scripts/UI/ObjectCounter.cs
+++ b/Assets/Scripts/UI/ObjectCounter.cs
@@ -84,19 +84,19 @@ public class ObjectCounter : MonoBehaviour
           break;
         case EditorComboIndicator.AchievementClassic: // Achievement (+) Classic
           UpdateAchievementColor(accValues[0]);
-          statusAchievement.text = string.Format("{0:0.00}%", accValues[0]);
+          statusAchievement.text = string.Format("{0,6:0.00}%", accValues[0]);
           break;
         case EditorComboIndicator.AchievementDownClassic: // Achievement (-) Classic (from 100%)
           UpdateAchievementColor(accValues[1]);
-          statusAchievement.text = string.Format("{0:0.00}%", accValues[1]);
+          statusAchievement.text = string.Format("{0,6:0.00}%", accValues[1]);
           break;
         case EditorComboIndicator.AchievementDeluxe: // Achievement (+) Deluxe
           UpdateAchievementColor(accValues[2]);
-          statusAchievement.text = string.Format("{0:0.0000}%", accValues[2]);
+          statusAchievement.text = string.Format("{0,8:0.0000}%", accValues[2]);
           break;
         case EditorComboIndicator.AchievementDownDeluxe: // Achievement (-) Deluxe (from 100%)
           UpdateAchievementColor(accValues[3]);
-          statusAchievement.text = string.Format("{0:0.0000}%", accValues[3]);
+          statusAchievement.text = string.Format("{0,8:0.0000}%", accValues[3]);
           break;
         case EditorComboIndicator.ScoreDeluxe: // DX Score (+)
           statusDXScore.text = DxExNowScore().ToString();


### PR DESCRIPTION
It's known that any slides that are **mirrored**, or `pq`-slides have **6 of 8** of it's point inverted.
This fix attempt makes any `SlideDrop`'s Star object doesn't go "backwards".

Also, in addition the **W-slide** star angle deltas are fixed from `45°` to `22.5°` with proper offset as well.