### PR TITLE
Supplement Screen Recorder Stoppers

### DIFF
--- a/Assets/Scripts/ScreenRecorder.cs
+++ b/Assets/Scripts/ScreenRecorder.cs
@@ -44,7 +44,9 @@ public class ScreenRecorder : MonoBehaviour
             var arguments = string.Format(File.ReadAllText(Application.streamingAssetsPath+ "\\ffarguments.txt"),
                 Screen.width, Screen.height, wavpath, outputfile );
             var startinfo = new ProcessStartInfo(Application.streamingAssetsPath + "\\ffmpeg.exe", arguments);
+            startinfo.UseShellExecute = false;
             startinfo.WorkingDirectory = maidata_path;
+            startinfo.EnvironmentVariables.Add("FFREPORT", "file=out.log:level=24");
             print(arguments);
             
             var p = Process.Start(startinfo);

--- a/Assets/Scripts/ScreenRecorder.cs
+++ b/Assets/Scripts/ScreenRecorder.cs
@@ -27,6 +27,8 @@ public class ScreenRecorder : MonoBehaviour
     bool isRecording = false;
     IEnumerator CaptureScreen(string maidata_path)
     {
+        var timeProvider = GameObject.Find("AudioTimeProvider").GetComponent<AudioTimeProvider>();
+        var bgManager = GameObject.Find("Background").GetComponent<BGManager>();
         if (Screen.width % 2 != 0 || Screen.height % 2 != 0)
         {
             GameObject.Find("ErrText").GetComponent<Text>().text = "无法开始编码，因为分辨率宽度或高度不是偶数。\nCan not start render because the width/height is not even.\n当前分辨率:"+Screen.width+"x"+Screen.height+"\n";
@@ -84,6 +86,8 @@ public class ScreenRecorder : MonoBehaviour
             else
                 GameObject.Find("ErrText").GetComponent<Text>().text += "编码器已退出\nFFmpeg Exited.\nExitCode:" + p.ExitCode;
         }
+        timeProvider.isStart = false;
+        bgManager.PauseVideo();
     }
 
     // Start is called before the first frame update

--- a/Assets/Scripts/ScreenRecorder.cs
+++ b/Assets/Scripts/ScreenRecorder.cs
@@ -32,6 +32,7 @@ public class ScreenRecorder : MonoBehaviour
         if (Screen.width % 2 != 0 || Screen.height % 2 != 0)
         {
             GameObject.Find("ErrText").GetComponent<Text>().text = "无法开始编码，因为分辨率宽度或高度不是偶数。\nCan not start render because the width/height is not even.\n当前分辨率:"+Screen.width+"x"+Screen.height+"\n";
+            yield break;
         }
         if (File.Exists(maidata_path + "\\out.mp4"))
             File.Delete(maidata_path + "\\out.mp4");

--- a/Assets/StreamingAssets/ffarguments.txt
+++ b/Assets/StreamingAssets/ffarguments.txt
@@ -1,1 +1,1 @@
--y -f rawvideo -vcodec rawvideo -pix_fmt rgba -s {0}x{1} -r 60 -i \\.\pipe\majdataRec -i {2} -vf "vflip" -c:v libx264 -preset fast -pix_fmt yuv420p -b:a 320k -c:a aac {3}
+-hide_banner -report -y -f rawvideo -vcodec rawvideo -pix_fmt rgba -s "{0}x{1}" -r 60 -i \\.\pipe\majdataRec -i "{2}" -vf "vflip" -c:v libx264 -preset fast -pix_fmt yuv420p -b:a 320k -c:a aac "{3}"


### PR DESCRIPTION
- MajdataView instantly *stops* once the recording is done.
- Prevent recording if current dimension is invalid.
- Engrave report filename into a constant one. (Log level maybe too high?)