### PR TITLE
Slide judge and BreakShine animation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ Skin/*
 majdata.json
 UserSettings/Layouts/default-2021.dwlt
 UserSettings/Layouts/default-2022.dwlt
+/SFX

--- a/Assets/Prefab/Hold_01.prefab
+++ b/Assets/Prefab/Hold_01.prefab
@@ -268,7 +268,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   time: 0
-  sortOrder: 0
+  noteSortOrder: 0
   LastFor: 1
   startPosition: 1
   speed: 1
@@ -276,9 +276,12 @@ MonoBehaviour:
   isEX: 0
   isBreak: 0
   tapSpr: {fileID: 21300000, guid: 69b328dbae9628c44b0882a049fcbf0b, type: 3}
+  holdOnSpr: {fileID: 0}
   eachSpr: {fileID: 21300000, guid: 2dcf4edddd7b12342a99c1ce92e6e0ab, type: 3}
+  eachHoldOnSpr: {fileID: 0}
   exSpr: {fileID: 0}
   breakSpr: {fileID: 0}
+  breakHoldOnSpr: {fileID: 0}
   eachLine: {fileID: 21300000, guid: 1a40750ad0e4fb747aeeb83536f52d09, type: 3}
   breakLine: {fileID: 21300000, guid: c190fb744a4bc94429a7cbce66f9fa9b, type: 3}
   holdEachEnd: {fileID: 21300000, guid: 525ed29f5ee445942973894c8193d8fb, type: 3}
@@ -291,3 +294,4 @@ MonoBehaviour:
   exEffectTap: {r: 1, g: 0.6745283, b: 0.8829237, a: 1}
   exEffectEach: {r: 1, g: 0.9943893, b: 0.4669811, a: 1}
   exEffectBreak: {r: 1, g: 0.99607843, b: 0.46666667, a: 1}
+  breakMaterial: {fileID: 2100000, guid: 6cea13e5ba8275446be27a38daed20c7, type: 2}

--- a/Assets/Prefab/Star_01.prefab
+++ b/Assets/Prefab/Star_01.prefab
@@ -25,13 +25,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3599915660479470153}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4554767367093168497}
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!212 &3599915660479470151
 SpriteRenderer:
@@ -98,6 +99,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   time: 0
+  noteSortOrder: 0
   startPosition: 1
   speed: 1
   rotateSpeed: 1
@@ -116,11 +118,13 @@ MonoBehaviour:
   exSpr_Double: {fileID: 0}
   eachLine: {fileID: 21300000, guid: 1a40750ad0e4fb747aeeb83536f52d09, type: 3}
   breakLine: {fileID: 21300000, guid: c190fb744a4bc94429a7cbce66f9fa9b, type: 3}
+  BreakShine: {fileID: 0}
   slide: {fileID: 0}
   tapLine: {fileID: 7599635926637845735, guid: 170f7f7a95689ea479fc7270d6ebf074, type: 3}
   exEffectTap: {r: 0.6745098, g: 0.98440695, b: 1, a: 1}
   exEffectEach: {r: 1, g: 0.9943893, b: 0.4669811, a: 1}
   exEffectBreak: {r: 1, g: 0.99607843, b: 0.46666667, a: 1}
+  breakMaterial: {fileID: 2100000, guid: 6cea13e5ba8275446be27a38daed20c7, type: 2}
 --- !u!1 &5847727196508993278
 GameObject:
   m_ObjectHideFlags: 0
@@ -145,12 +149,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5847727196508993278}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 3599915660479470150}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!212 &3281440940452495023
 SpriteRenderer:

--- a/Assets/Prefab/Tap_01.prefab
+++ b/Assets/Prefab/Tap_01.prefab
@@ -183,7 +183,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   time: 0
-  sortOrder: 0
+  noteSortOrder: 0
   startPosition: 1
   speed: 1
   isEach: 0
@@ -201,3 +201,4 @@ MonoBehaviour:
   exEffectTap: {r: 1, g: 0.6745283, b: 0.8829237, a: 1}
   exEffectEach: {r: 1, g: 0.9943893, b: 0.4669811, a: 1}
   exEffectBreak: {r: 1, g: 0.99607843, b: 0.46666667, a: 1}
+  breakMaterial: {fileID: 2100000, guid: 6cea13e5ba8275446be27a38daed20c7, type: 2}

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -1669,6 +1669,7 @@ MonoBehaviour:
   - {fileID: 8148946950682681393, guid: d050f65c3f52d524ab26963738702536, type: 3}
   - {fileID: 8389343569395675099, guid: 32868e5f4fa463f4c905e870406abea5, type: 3}
   - {fileID: 349982270078930302, guid: d0fd46e58bee17740a889818d94c8816, type: 3}
+  breakMaterial: {fileID: 2100000, guid: 6cea13e5ba8275446be27a38daed20c7, type: 2}
   BreakShine: {fileID: 9100000, guid: c28f56116f6dc34408d6f0f544f1e2cc, type: 2}
   JudgeBreakShine: {fileID: 9100000, guid: 68e114e3215572c4380cbd3b06c36ad0, type: 2}
   HoldShine: {fileID: 9100000, guid: 3fcb4587ef8c7f141969450782191592, type: 2}

--- a/Assets/Scripts/AudioTimeProvider.cs
+++ b/Assets/Scripts/AudioTimeProvider.cs
@@ -25,7 +25,12 @@ public class AudioTimeProvider : MonoBehaviour
                 AudioTime = (Time.realtimeSinceStartup - startTime) * speed + offset;
         }
     }
+    public float GetFrame()
+    {
+        var _audioTime = AudioTime * 1000;
 
+        return _audioTime / 16.6667f;
+    }
     public void SetStartTime(long _ticks, float _offset, float _speed, bool _isRecord = false)
     {
         ticks = _ticks;

--- a/Assets/Scripts/Interfaces.meta
+++ b/Assets/Scripts/Interfaces.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: db629c433eb21b64fbd288c43665eb0c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interfaces/IFlasher.cs
+++ b/Assets/Scripts/Interfaces/IFlasher.cs
@@ -1,0 +1,8 @@
+﻿
+namespace Assets.Scripts.Interfaces
+{
+    public interface IFlasher
+    {
+        bool CanShine();
+    }
+}

--- a/Assets/Scripts/Interfaces/IFlasher.cs.meta
+++ b/Assets/Scripts/Interfaces/IFlasher.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 55c4b88f282c7cb429ba7cafa444fc27
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/JsonDataLoader.cs
+++ b/Assets/Scripts/JsonDataLoader.cs
@@ -622,7 +622,7 @@ public class JsonDataLoader : MonoBehaviour
             }
         }
 
-        for (var i = subSlide.Count - 1; i >= 0; i--)
+        for (var i = 0; i <= subSlide.Count - 1; i++)
             if (note.noteContent.Contains('w')) //wifi
                 InstantiateWifi(timing, subSlide[i], i != 0, i == subSlide.Count - 1);
             else
@@ -642,6 +642,8 @@ public class JsonDataLoader : MonoBehaviour
 
         var GOnote = Instantiate(starPrefab, notes.transform);
         var NDCompo = GOnote.GetComponent<StarDrop>();
+
+        
 
         // note的图层顺序
         NDCompo.noteSortOrder = noteSortOrder;

--- a/Assets/Scripts/JsonDataLoader.cs
+++ b/Assets/Scripts/JsonDataLoader.cs
@@ -37,7 +37,7 @@ public class JsonDataLoader : MonoBehaviour
 
     private ObjectCounter ObjectCounter;
 
-    private int slideLayer = -10000;
+    private int slideLayer = -1;
     private int noteSortOrder = 0;
 
     private static readonly Dictionary<SimaiNoteType, int> NOTE_LAYER_COUNT = new Dictionary<SimaiNoteType, int>()
@@ -720,7 +720,8 @@ public class JsonDataLoader : MonoBehaviour
         WifiCompo.time = (float)note.slideStartTime;
         WifiCompo.LastFor = (float)note.slideTime;
         WifiCompo.sortIndex = slideLayer;
-        slideLayer += 5;
+        slideLayer -= SLIDE_AREA_STEP_MAP["wifi"].Last();
+        //slideLayer += 5;
     }
 
     private void InstantiateStar(SimaiTimingPoint timing, SimaiNote note, bool isGroupPart, bool isGroupPartEnd)
@@ -833,8 +834,9 @@ public class JsonDataLoader : MonoBehaviour
         SliCompo.time = (float)note.slideStartTime;
         SliCompo.LastFor = (float)note.slideTime;
         //SliCompo.sortIndex = -7000 + (int)((lastNoteTime - timing.time) * -100) + sort * 5;
-        SliCompo.sortIndex = slideLayer++;
-        slideLayer += 5;
+        SliCompo.sortIndex = slideLayer;
+        slideLayer -= SLIDE_AREA_STEP_MAP[slideShape].Last();
+        //slideLayer += 5;
     }
 
     private bool detectJustType(string content,out int endPos)

--- a/Assets/Scripts/JsonDataLoader.cs
+++ b/Assets/Scripts/JsonDataLoader.cs
@@ -21,6 +21,7 @@ public class JsonDataLoader : MonoBehaviour
     public GameObject notes;
     public GameObject star_slidePrefab;
     public GameObject[] slidePrefab;
+    public Material breakMaterial;
     public RuntimeAnimatorController BreakShine;
     public RuntimeAnimatorController JudgeBreakShine;
     public RuntimeAnimatorController HoldShine;
@@ -671,6 +672,7 @@ public class JsonDataLoader : MonoBehaviour
         WifiCompo.eachStar = customSkin.Star_Each;
         WifiCompo.breakStar = customSkin.Star_Break;
         WifiCompo.judgeBreakShine = JudgeBreakShine;
+        WifiCompo.breakMaterial = breakMaterial;
         WifiCompo.slideShine = BreakShine;
         WifiCompo.areaStep = new List<int>(SLIDE_AREA_STEP_MAP["wifi"]);
         WifiCompo.slideConst = SLIDE_AREA_CONST["wifi"];
@@ -767,6 +769,7 @@ public class JsonDataLoader : MonoBehaviour
         SliCompo.spriteEach = customSkin.Slide_Each;
         SliCompo.spriteBreak = customSkin.Slide_Break;
         SliCompo.slideShine = BreakShine;
+        SliCompo.breakMaterial = breakMaterial;
         SliCompo.judgeBreakShine = JudgeBreakShine;
         SliCompo.areaStep = new List<int>(SLIDE_AREA_STEP_MAP[slideShape]);
         SliCompo.slideConst = SLIDE_AREA_CONST[slideShape]; 

--- a/Assets/Scripts/Notes/BreakShineController.cs
+++ b/Assets/Scripts/Notes/BreakShineController.cs
@@ -1,0 +1,30 @@
+using Assets.Scripts.Interfaces;
+using System;
+using UnityEngine;
+
+public class BreakShineController : MonoBehaviour
+{
+    public IFlasher parent;
+
+    SpriteRenderer spriteRenderer;
+    AudioTimeProvider timeProvider;
+    // Start is called before the first frame update
+    void Start()
+    {
+        
+    }
+    // Update is called once per frame
+    void Update()
+    {
+        if(parent is not null && parent.CanShine())
+        {
+            var extra = Math.Max(Mathf.Sin(timeProvider.GetFrame() * 0.17f) * 0.5f, 0);
+            spriteRenderer.material.SetFloat("_Brightness", 0.95f + extra);
+        }
+    }
+    private void OnEnable()
+    {
+        spriteRenderer = GetComponent<SpriteRenderer>();
+        timeProvider = GameObject.Find("AudioTimeProvider").GetComponent<AudioTimeProvider>();
+    }
+}

--- a/Assets/Scripts/Notes/BreakShineController.cs.meta
+++ b/Assets/Scripts/Notes/BreakShineController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ed6b3090427271741b4fbd58eb888097
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Notes/HoldDrop.cs
+++ b/Assets/Scripts/Notes/HoldDrop.cs
@@ -1,5 +1,4 @@
 ﻿using UnityEngine;
-using static UnityEditor.PlayerSettings;
 
 public class HoldDrop : NoteLongDrop
 {

--- a/Assets/Scripts/Notes/HoldDrop.cs
+++ b/Assets/Scripts/Notes/HoldDrop.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using System;
+using UnityEngine;
 
 public class HoldDrop : NoteLongDrop
 {
@@ -36,6 +37,8 @@ public class HoldDrop : NoteLongDrop
     public Color exEffectEach;
     public Color exEffectBreak;
     private Animator animator;
+
+    public Material breakMaterial;
 
     private bool breakAnimStart;
     private SpriteRenderer exSpriteRender;
@@ -90,6 +93,7 @@ public class HoldDrop : NoteLongDrop
             lineSpriteRender.sprite = breakLine;
             holdEndRender.sprite = holdBreakEnd;
             if (isEX) exSpriteRender.color = exEffectBreak;
+            spriteRenderer.material = breakMaterial;
         }
 
         spriteRenderer.forceRenderingOff = true;
@@ -112,12 +116,12 @@ public class HoldDrop : NoteLongDrop
         spriteRenderer.forceRenderingOff = false;
         if (isEX) exSpriteRender.forceRenderingOff = false;
 
-        if (isBreak && !breakAnimStart)
-        {
-            breakAnimStart = true;
-            animator.runtimeAnimatorController = BreakShine;
-            animator.enabled = true; // break hold闪烁
-        }
+        //if (isBreak && !breakAnimStart)
+        //{
+        //    breakAnimStart = true;
+        //    animator.runtimeAnimatorController = BreakShine;
+        //    animator.enabled = true; // break hold闪烁
+        //}
 
         spriteRenderer.size = new Vector2(1.22f, 1.4f);
 
@@ -140,6 +144,13 @@ public class HoldDrop : NoteLongDrop
         transform.rotation = Quaternion.Euler(0, 0, -22.5f + -45f * (startPosition - 1));
         tapLine.transform.rotation = transform.rotation;
         holdEffect.transform.position = getPositionFromDistance(4.8f);
+
+        if (isBreak && !holdAnimStart)
+        {
+            var extra = Math.Max(Mathf.Sin(timeProvider.GetFrame() * 0.17f) * 0.5f, 0);
+            spriteRenderer.material.SetFloat("_Brightness", 0.95f + extra);
+        }
+
 
         if (destScale > 0.3f) tapLine.SetActive(true);
 

--- a/Assets/Scripts/Notes/NoteEffectManager.cs
+++ b/Assets/Scripts/Notes/NoteEffectManager.cs
@@ -1,5 +1,4 @@
 ﻿using UnityEngine;
-using static UnityEditor.PlayerSettings;
 
 public class NoteEffectManager : MonoBehaviour
 {

--- a/Assets/Scripts/Notes/SlideDrop.cs
+++ b/Assets/Scripts/Notes/SlideDrop.cs
@@ -294,10 +294,10 @@ public class SlideDrop : NoteLongDrop,IFlasher
         {
             var sr = gm.GetComponent<SpriteRenderer>();
             sr.color = new Color(1f, 1f, 1f, 0f);
-            sr.sortingOrder += sortIndex;
+            sr.sortingOrder = sortIndex--;
             sr.sortingLayerName = "Slide";
             if (isBreak)
-            {
+            {                
                 sr.sprite = spriteBreak;
                 sr.material = breakMaterial;
                 sr.material.SetFloat("_Brightness", 0.95f);
@@ -318,7 +318,6 @@ public class SlideDrop : NoteLongDrop,IFlasher
             }
         }
     }
-
     private void setSlideBarAlpha(float alpha)
     {
         foreach (var gm in slideBars) gm.GetComponent<SpriteRenderer>().color = new Color(1f, 1f, 1f, alpha);

--- a/Assets/Scripts/Notes/StarDrop.cs
+++ b/Assets/Scripts/Notes/StarDrop.cs
@@ -1,4 +1,6 @@
-﻿using UnityEngine;
+﻿using System;
+using Unity.Mathematics;
+using UnityEngine;
 
 public class StarDrop : NoteDrop
 {
@@ -36,6 +38,8 @@ public class StarDrop : NoteDrop
     public Color exEffectEach;
     public Color exEffectBreak;
     private Animator animator;
+
+    public Material breakMaterial;
 
     private bool breakAnimStart;
     private SpriteRenderer exSpriteRender;
@@ -78,10 +82,11 @@ public class StarDrop : NoteDrop
                 lineSpriteRender.sprite = breakLine;
                 spriteRenderer.sprite = breakSpr_Double;
                 if (isEX) exSpriteRender.color = exEffectBreak;
-                var anim = gameObject.AddComponent<Animator>(); // break star闪烁
-                anim.runtimeAnimatorController = BreakShine;
-                anim.enabled = false;
-                animator = anim;
+                spriteRenderer.material = breakMaterial;
+                //var anim = gameObject.AddComponent<Animator>(); // break star闪烁
+                //anim.runtimeAnimatorController = BreakShine;
+                //anim.enabled = false;
+                //animator = anim;
             }
         }
         else
@@ -101,10 +106,11 @@ public class StarDrop : NoteDrop
                 lineSpriteRender.sprite = breakLine;
                 spriteRenderer.sprite = breakSpr;
                 if (isEX) exSpriteRender.color = exEffectBreak;
-                var anim = gameObject.AddComponent<Animator>(); // break star闪烁
-                anim.runtimeAnimatorController = BreakShine;
-                anim.enabled = false;
-                animator = anim;
+                spriteRenderer.material = breakMaterial;
+                //var anim = gameObject.AddComponent<Animator>(); // break star闪烁
+                //anim.runtimeAnimatorController = BreakShine;
+                //anim.enabled = false;
+                //animator = anim;
             }
         }
 
@@ -131,12 +137,18 @@ public class StarDrop : NoteDrop
             if (isEX) exSpriteRender.forceRenderingOff = false;
         }
 
-        if (isBreak && !breakAnimStart)
+        if(isBreak)
         {
-            breakAnimStart = true;
-            animator.enabled = true;
-            animator.Play("BreakShine", -1, 0.5f);
+            var extra = Math.Max(Mathf.Sin(timeProvider.GetFrame() * 0.17f) * 0.5f,0);
+            spriteRenderer.material.SetFloat("_Brightness",0.95f + extra);
         }
+
+        //if (isBreak && !breakAnimStart)
+        //{
+        //    breakAnimStart = true;
+        //    animator.enabled = true;
+        //    animator.Play("BreakShine", -1, 0.5f);
+        //}
 
         if (timing > 0)
         {

--- a/Assets/Scripts/Notes/TapDrop.cs
+++ b/Assets/Scripts/Notes/TapDrop.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using System;
+using UnityEngine;
 
 public class TapDrop : NoteDrop
 {
@@ -28,6 +29,8 @@ public class TapDrop : NoteDrop
     public Color exEffectEach;
     public Color exEffectBreak;
     private Animator animator;
+
+    public Material breakMaterial;
 
     private bool breakAnimStart;
     private SpriteRenderer exSpriteRender;
@@ -74,10 +77,11 @@ public class TapDrop : NoteDrop
             spriteRenderer.sprite = breakSpr;
             lineSpriteRender.sprite = breakLine;
             if (isEX) exSpriteRender.color = exEffectBreak;
-            var anim = gameObject.AddComponent<Animator>(); // break tap闪烁
-            anim.runtimeAnimatorController = BreakShine;
-            anim.enabled = false;
-            animator = anim;
+            spriteRenderer.material = breakMaterial;
+            //var anim = gameObject.AddComponent<Animator>(); // break tap闪烁
+            //anim.runtimeAnimatorController = BreakShine;
+            //anim.enabled = false;
+            //animator = anim;
         }
 
         spriteRenderer.forceRenderingOff = true;
@@ -98,12 +102,19 @@ public class TapDrop : NoteDrop
 
         spriteRenderer.forceRenderingOff = false;
         if (isEX) exSpriteRender.forceRenderingOff = false;
-        if (isBreak && !breakAnimStart)
+
+        if (isBreak)
         {
-            breakAnimStart = true;
-            animator.enabled = true;
-            animator.Play("BreakShine", -1, 0.5f);
+            var extra = Math.Max(Mathf.Sin(timeProvider.GetFrame() * 0.17f) * 0.5f, 0);
+            spriteRenderer.material.SetFloat("_Brightness", 0.95f + extra);
         }
+
+        //if (isBreak && !breakAnimStart)
+        //{
+        //    breakAnimStart = true;
+        //    animator.enabled = true;
+        //    animator.Play("BreakShine", -1, 0.5f);
+        //}
 
         if (timing > 0)
         {

--- a/Assets/Scripts/Notes/TouchHoldDrop.cs
+++ b/Assets/Scripts/Notes/TouchHoldDrop.cs
@@ -66,6 +66,7 @@ public class TouchHoldDrop : NoteLongDrop
 
         if (timing > LastFor)
         {
+            transform.Rotate(0, 180f, 90f);
             Instantiate(tapEffect, transform.position, transform.rotation);
             GameObject.Find("ObjectCounter").GetComponent<ObjectCounter>().holdCount++;
             if (isFirework)

--- a/Assets/Scripts/Notes/WifiDrop.cs
+++ b/Assets/Scripts/Notes/WifiDrop.cs
@@ -158,7 +158,7 @@ public class WifiDrop : NoteLongDrop,IFlasher
 
             sbRender.Add(sr);
             sr.color = new Color(1f, 1f, 1f, 0f);
-            sr.sortingOrder += sortIndex;
+            sr.sortingOrder = sortIndex--;
             sr.sortingLayerName = "Slide";
         }
     }


### PR DESCRIPTION
## Issue
#144  
## Feature
- Slide
  - Slide在进入最后一个判定区时会移除剩余的Slide箭头
  - Slide判定时机更改为进入最后一个判定区的瞬间（有助于修改速度不同但完成时间点相同的Slide）
  - Slide会等待片刻再完成判定（在长Slide中尤为明显）
- 使用正弦函数与当前播放时间控制Break闪烁特效
## Fix
- Break Each WIFI星星头贴图错误
- 所有Break闪烁特效同步
- Slide Star终点修改为具体键位
- Slide与组合Slide的图层问题
   - 正确的顺序：后出现的Slide位于上一条Slide的下方
- TouchHold判定动画板正